### PR TITLE
Su

### DIFF
--- a/su.c
+++ b/su.c
@@ -545,6 +545,12 @@ int su_main(int argc, char *argv[], int need_client) {
         allow(&ctx, NULL);
     }
 
+    // autogrant system apps
+    if (ctx.from.uid == 1000) {
+        ALOGD("Allowing system app.");
+        allow(&ctx, NULL);
+    }
+
     const char *packageName = resolve_package_name(ctx.from.uid);
     if (!appops_start_op_su(ctx.from.uid, packageName)) {
         ALOGD("Allowing via appops.");

--- a/su.c
+++ b/su.c
@@ -309,12 +309,12 @@ int access_disabled(const struct su_initiator *from) {
         if (data != NULL) {
             len = strlen(data);
             if (len >= PROPERTY_VALUE_MAX)
-                memcpy(enabled, "0", 2);
+                memcpy(enabled, "1", 2);
             else
                 memcpy(enabled, data, len + 1);
             free(data);
         } else
-            memcpy(enabled, "0", 2);
+            memcpy(enabled, "1", 2);
 
         /* enforce persist.sys.root_access on non-eng builds for apps */
         if (strcmp("eng", build_type) != 0 &&


### PR DESCRIPTION
Reverts: https://github.com/CyanogenMod/android_system_extras_su/commit/a1229fc8ff5227a2d51b3dc91eb7dba0a1171be2

persist.sys.root_access is being set but we should default to having root access.

Related: https://github.com/aopp/android_vendor_px/pull/33